### PR TITLE
fix: add error handling for Navidrome server unavailability

### DIFF
--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -95,6 +95,15 @@ button {
   margin-right: 5px;
 }
 
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f6f6f6;

--- a/apps/desktop/src/components/CoverArtImage.tsx
+++ b/apps/desktop/src/components/CoverArtImage.tsx
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react';
+import { useMusicStore } from '../lib/musicStore';
+
+interface CoverArtImageProps {
+  src: string;
+  alt: string;
+  style?: React.CSSProperties;
+  fallback?: React.ReactNode;
+  timeout?: number; // Timeout em milissegundos (padrão: 5000ms)
+}
+
+export default function CoverArtImage({
+  src,
+  alt,
+  style,
+  fallback,
+  timeout = 5000,
+}: CoverArtImageProps) {
+  const [imageState, setImageState] = useState<'loading' | 'loaded' | 'error'>('loading');
+  const { setServerAvailable } = useMusicStore();
+
+  useEffect(() => {
+    if (!src) {
+      setImageState('error');
+      return;
+    }
+
+    setImageState('loading');
+    let timeoutId: number;
+
+    const img = new Image();
+
+    const handleLoad = () => {
+      clearTimeout(timeoutId);
+      setImageState('loaded');
+      setServerAvailable(true);
+    };
+
+    const handleError = () => {
+      clearTimeout(timeoutId);
+      setImageState('error');
+      setServerAvailable(false);
+    };
+
+    // Timeout para considerar como erro
+    timeoutId = window.setTimeout(() => {
+      setImageState('error');
+      setServerAvailable(false);
+      img.src = ''; // Cancela o carregamento
+    }, timeout);
+
+    img.onload = handleLoad;
+    img.onerror = handleError;
+    img.src = src;
+
+    return () => {
+      clearTimeout(timeoutId);
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [src, timeout, setServerAvailable]);
+
+  if (imageState === 'loading') {
+    return (
+      <div
+        style={{
+          ...style,
+          backgroundColor: '#393939',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: '24px',
+            height: '24px',
+            border: '2px solid #8d8d8d',
+            borderTopColor: 'transparent',
+            borderRadius: '50%',
+            animation: 'spin 0.8s linear infinite',
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (imageState === 'error') {
+    if (fallback) {
+      return <>{fallback}</>;
+    }
+    return (
+      <div
+        style={{
+          ...style,
+          backgroundColor: '#393939',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#8d8d8d',
+          fontSize: '2rem',
+        }}
+      >
+        {alt.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+
+  return <img src={src} alt={alt} style={style} />;
+}

--- a/apps/desktop/src/components/MusicPlayer.tsx
+++ b/apps/desktop/src/components/MusicPlayer.tsx
@@ -1,5 +1,6 @@
 import { useMusicStore } from '../lib/musicStore';
 import { navidrome } from '../lib/navidrome';
+import CoverArtImage from './CoverArtImage';
 import {
   PlayFilled,
   PauseFilled,
@@ -10,6 +11,7 @@ import {
   Shuffle,
   Repeat,
   RepeatOne,
+  WarningAlt,
 } from '@carbon/icons-react';
 
 function formatTime(seconds: number): string {
@@ -28,6 +30,7 @@ export default function MusicPlayer() {
     volume,
     shuffle,
     repeat,
+    isServerAvailable,
     playPause,
     next,
     previous,
@@ -65,17 +68,34 @@ export default function MusicPlayer() {
     >
       {/* Song Info */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', minWidth: '250px' }}>
-        {coverUrl && (
-          <img
+        {coverUrl ? (
+          <CoverArtImage
             src={coverUrl}
-            alt={currentSong.album}
+            alt={currentSong.album || currentSong.title}
             style={{
               width: '56px',
               height: '56px',
               borderRadius: '4px',
               objectFit: 'cover',
             }}
+            timeout={5000}
           />
+        ) : (
+          <div
+            style={{
+              width: '56px',
+              height: '56px',
+              borderRadius: '4px',
+              backgroundColor: '#393939',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#8d8d8d',
+              fontSize: '1.5rem',
+            }}
+          >
+            {currentSong.title.charAt(0).toUpperCase()}
+          </div>
         )}
         <div style={{ flex: 1, minWidth: 0 }}>
           <div
@@ -102,6 +122,22 @@ export default function MusicPlayer() {
             {currentSong.artist}
           </div>
         </div>
+        {!isServerAvailable && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              color: '#da1e28',
+              fontSize: '0.75rem',
+              paddingRight: '0.5rem',
+            }}
+            title="Servidor Navidrome indisponível"
+          >
+            <WarningAlt size={16} />
+            <span>Offline</span>
+          </div>
+        )}
       </div>
 
       {/* Player Controls */}

--- a/apps/desktop/src/lib/musicStore.ts
+++ b/apps/desktop/src/lib/musicStore.ts
@@ -7,6 +7,10 @@ interface MusicStore extends PlayerState {
   // Audio element
   audio: HTMLAudioElement | null;
 
+  // Connection state
+  isServerAvailable: boolean;
+  setServerAvailable: (_available: boolean) => void;
+
   // Actions
   setCurrentSong: (_song: Song | null) => void;
   addToQueue: (_songs: Song[]) => void;
@@ -40,6 +44,11 @@ export const useMusicStore = create<MusicStore>((set, get) => ({
   shuffle: false,
   repeat: 'none',
   audio: null,
+  isServerAvailable: true,
+
+  setServerAvailable: (available) => {
+    set({ isServerAvailable: available });
+  },
 
   // Initialize audio element
   initAudio: () => {

--- a/apps/desktop/src/pages/Music.tsx
+++ b/apps/desktop/src/pages/Music.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { navidrome } from '../lib/navidrome';
 import { useMusicStore } from '../lib/musicStore';
 import MusicPlayer from '../components/MusicPlayer';
+import CoverArtImage from '../components/CoverArtImage';
 import type { Artist, Album, Song } from '../types/music';
 
 export default function Music() {
@@ -353,10 +354,11 @@ export default function Music() {
         <div>
           <div style={{ display: 'flex', gap: '2rem', marginBottom: '2rem' }}>
             {selectedAlbum.coverArt && (
-              <img
+              <CoverArtImage
                 src={navidrome.getCoverArtUrl(selectedAlbum.coverArt, 300)}
                 alt={selectedAlbum.name}
                 style={{ width: '200px', height: '200px', borderRadius: '8px', objectFit: 'cover' }}
+                timeout={5000}
               />
             )}
             <div>
@@ -478,12 +480,30 @@ export default function Music() {
                 style={{ cursor: 'pointer', padding: '1rem' }}
                 onClick={() => handleAlbumClick(album)}
               >
-                {album.coverArt && (
-                  <img
+                {album.coverArt ? (
+                  <CoverArtImage
                     src={navidrome.getCoverArtUrl(album.coverArt, 200)}
                     alt={album.name}
-                    style={{ width: '100%', borderRadius: '4px', marginBottom: '0.5rem' }}
+                    style={{ width: '100%', aspectRatio: '1', borderRadius: '4px', marginBottom: '0.5rem', objectFit: 'cover' }}
+                    timeout={5000}
                   />
+                ) : (
+                  <div
+                    style={{
+                      width: '100%',
+                      aspectRatio: '1',
+                      backgroundColor: '#393939',
+                      borderRadius: '4px',
+                      marginBottom: '0.5rem',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '3rem',
+                      color: '#8d8d8d'
+                    }}
+                  >
+                    {(album.name === '[Unknown Album]' ? album.artist : album.name)?.charAt(0).toUpperCase()}
+                  </div>
                 )}
                 <div style={{ fontWeight: 500, marginBottom: '0.25rem' }}>
                   {album.name === '[Unknown Album]' ? album.artist || 'Álbum Desconhecido' : album.name}
@@ -528,7 +548,7 @@ export default function Music() {
                   onClick={() => handleArtistClick(artist)}
                 >
                   {imageUrl ? (
-                    <img
+                    <CoverArtImage
                       src={imageUrl}
                       alt={artist.name}
                       style={{
@@ -538,10 +558,25 @@ export default function Music() {
                         borderRadius: '4px',
                         marginBottom: '0.5rem'
                       }}
-                      onError={(e) => {
-                        // Fallback: esconde a imagem se der erro
-                        e.currentTarget.style.display = 'none';
-                      }}
+                      timeout={5000}
+                      fallback={
+                        <div
+                          style={{
+                            width: '100%',
+                            aspectRatio: '1',
+                            backgroundColor: '#393939',
+                            borderRadius: '4px',
+                            marginBottom: '0.5rem',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            fontSize: '3rem',
+                            color: '#8d8d8d'
+                          }}
+                        >
+                          {artist.name.charAt(0).toUpperCase()}
+                        </div>
+                      }
                     />
                   ) : (
                     <div


### PR DESCRIPTION
## Summary
- Implementa tratamento de erro abrangente para quando o servidor Navidrome está indisponível ou inacessível
- Melhora a experiência do usuário com feedback visual apropriado

## Mudanças Principais
- ✅ Criado componente `CoverArtImage` com estados de timeout e loading
- ✅ Adicionado estado `isServerAvailable` ao music store
- ✅ Indicador "Offline" no player quando servidor está down
- ✅ Substituídas todas as imagens de capa por componente com error handling
- ✅ Timeout de 5 segundos para carregamento de imagens com spinner animado
- ✅ Fallback inteligente (primeira letra) quando imagens falham

## Comportamento
Quando o Navidrome está offline:
- Loaders aparecem por 5 segundos nas capas de álbuns/artistas
- Depois do timeout, exibe fallback (primeira letra do nome)
- Badge "Offline" com ícone de aviso aparece no player
- Música que já estava tocando continua (stream já carregado)

## Test plan
- [x] Pausar Docker Desktop com música tocando
- [x] Verificar loaders aparecem nas capas
- [x] Verificar fallback após timeout
- [x] Verificar badge "Offline" no player
- [x] Confirmar música continua tocando
- [x] Testes passando (Jest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)